### PR TITLE
conf: correct `description_file` config key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.sysconfig import get_python_inc
 
 setup(
     name='zr_murmur2',
-    version='3.4.1',
+    version='3.4.2',
     ext_modules=[
         Extension(
             "zr_murmur2",


### PR DESCRIPTION
The dashed config keys are no longer supported.